### PR TITLE
Improve AI review efficiency and repo context

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Automated AI-powered code review using OpenAI GPT models for GitHub pull request
 - 📋 JSON artifacts for audit trails
 - 🖥️ Local review mode for pre-push validation with stdout JSON output
 - 🎯 More stable reruns with deterministic review settings and completeness guidance
+- 🧱 Structured JSON output from the Responses API for reliable parsing
+- 📚 Repository-specific review instructions through a workflow input
 - ✨ **NEW in v1.2.0:** Refined AI prompt reduces false positives and improves severity classification
 - ✨ **NEW in v1.1.0:** Robust plain-text parsing eliminates JSON encoding issues
 
@@ -42,9 +44,14 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           openai_api_key: ${{ secrets.OPENAI_API_KEY }}
           # Optional customization:
-          ai_model: 'gpt-5-mini'
+          ai_model: 'gpt-5.5'
           max_diff_chars: '180000'
+          max_review_files: '100'
+          max_output_tokens: '6000'
+          reasoning_effort: 'medium'
           fail_on_severity: '["high","critical","security"]'
+          review_instructions: |
+            Project-specific context for this repository.
       
       # Optional: Upload the detailed JSON report as an artifact
       - name: Upload AI Review Report
@@ -58,7 +65,7 @@ jobs:
 ### Version Options
 
 - **`@latest`** - Always use the newest version (recommended for most users)
-- **`@v1.2.3`** - Pin to a specific version (recommended for production environments)
+- **`@v1.2.4`** - Pin to a specific version (recommended for production environments)
 
 ## Local Review
 
@@ -86,9 +93,27 @@ It also prints the JSON report to stdout between `AI_REVIEW_JSON_START` and `AI_
 |-------|-------------|----------|---------|
 | `github_token` | GitHub token for API access | Yes | `${{ secrets.GITHUB_TOKEN }}` |
 | `openai_api_key` | OpenAI API key | Yes | - |
-| `ai_model` | OpenAI model to use | No | `gpt-5-mini` |
+| `ai_model` | OpenAI model to use | No | `gpt-5.5` |
 | `max_diff_chars` | Max characters in diff | No | `180000` |
+| `max_review_files` | Max changed files to fetch from the PR | No | `100` |
+| `max_output_tokens` | Max model output tokens for the review | No | `6000` |
+| `reasoning_effort` | Reasoning effort for supported models: `low`, `medium`, or `high` | No | `medium` |
 | `fail_on_severity` | Severities that fail the check | No | `["high","critical","security"]` |
+| `review_instructions` | Inline repository-specific review instructions | No | - |
+| `max_review_instructions_chars` | Max characters of review instructions to send | No | `12000` |
+
+## Repository Instructions
+
+For repo-specific context, pass `review_instructions` in the workflow. This keeps the review background explicit in CI configuration and avoids relying on repository checkout.
+
+Use this for architectural facts and project-specific false-positive guidance:
+
+```yaml
+with:
+  review_instructions: |
+    Controllers receive already validated input from route middleware; do not request duplicate validation in controllers unless a route lacks validation middleware.
+    Missing imports in changed Vue files are valid review findings when the diff clearly introduces a new unimported symbol.
+```
 
 ## Setup
 
@@ -108,7 +133,17 @@ It also prints the JSON report to stdout between `AI_REVIEW_JSON_START` and `AI_
 
 ## Changelog
 
-### v1.2.3 (Current)
+### v1.2.4
+
+**Model & Parsing Improvements:**
+- 🤖 **Updated default model**: Default reviewer model is now `gpt-5.5`
+- 🧱 **Structured review output**: Uses strict JSON schema output through the Responses API instead of relying on plain-text formatting
+- 🧼 **Reduced CI log exposure**: Stops logging the full model response body to GitHub Actions output
+- 🟢 **Aligned build target**: Bundles for Node 20 to match the declared GitHub Action runtime
+- 📚 **Added repo-specific instructions**: Supports a `review_instructions` workflow input and injects it into the prompt
+- ⚡ **Improved review efficiency**: Caps fetched files, uses bounded output, keeps medium reasoning by default, disables response storage, and reports PR coverage truncation in the review comment
+
+### v1.2.3
 
 **Local Review & Stability Improvements:**
 - 🖥️ **Added local review mode**: Run the same reviewer locally with `npm run review:local`

--- a/action.yml
+++ b/action.yml
@@ -18,17 +18,42 @@ inputs:
   ai_model:
     description: 'OpenAI model to use for code review'
     required: false
-    default: gpt-5-mini
+    default: gpt-5.5
   
   max_diff_chars:
     description: 'Maximum number of characters in diff to send to AI'
     required: false
     default: 180000
+
+  max_review_files:
+    description: 'Maximum number of changed files to fetch from the pull request for review'
+    required: false
+    default: 100
+
+  max_output_tokens:
+    description: 'Maximum model output tokens for the review response'
+    required: false
+    default: 6000
+
+  reasoning_effort:
+    description: 'Reasoning effort for models that support it: low, medium, or high'
+    required: false
+    default: medium
   
   fail_on_severity:
     description: 'JSON array of severities that should fail the check'
     required: false
     default: '["high","critical","security"]'
+
+  review_instructions:
+    description: 'Additional repository-specific review instructions to inject into the prompt'
+    required: false
+    default: ''
+
+  max_review_instructions_chars:
+    description: 'Maximum number of characters of repository review instructions to send to AI'
+    required: false
+    default: 12000
 
 runs:
   using: 'node20'

--- a/dist/index.js
+++ b/dist/index.js
@@ -17032,9 +17032,14 @@ var {
   INPUT_GITHUB_TOKEN: GITHUB_TOKEN,
   INPUT_OPENAI_API_KEY,
   OPENAI_API_KEY,
-  INPUT_AI_MODEL: AI_MODEL = "gpt-5-mini",
+  INPUT_AI_MODEL: AI_MODEL = "gpt-5.5",
   INPUT_MAX_DIFF_CHARS: MAX_DIFF_CHARS = "180000",
+  INPUT_MAX_REVIEW_FILES: MAX_REVIEW_FILES = "100",
+  INPUT_MAX_OUTPUT_TOKENS: MAX_OUTPUT_TOKENS = "6000",
+  INPUT_REASONING_EFFORT: REASONING_EFFORT = "medium",
   INPUT_FAIL_ON_SEVERITY: FAIL_ON_SEVERITY = '["high","critical","security"]',
+  INPUT_REVIEW_INSTRUCTIONS: REVIEW_INSTRUCTIONS = "",
+  INPUT_MAX_REVIEW_INSTRUCTIONS_CHARS: MAX_REVIEW_INSTRUCTIONS_CHARS = "12000",
   GITHUB_REPOSITORY
 } = process.env;
 var REVIEW_OPENAI_API_KEY = INPUT_OPENAI_API_KEY || OPENAI_API_KEY;
@@ -17064,6 +17069,11 @@ if (!isLocalMode && !Number.isInteger(prNumber)) {
 }
 var octo = isLocalMode ? null : new import_rest.Octokit({ auth: GITHUB_TOKEN });
 var openai = new OpenAI({ apiKey: REVIEW_OPENAI_API_KEY });
+var maxDiffChars = parsePositiveInt(MAX_DIFF_CHARS, 18e4);
+var maxReviewFiles = Math.min(parsePositiveInt(MAX_REVIEW_FILES, 100), 100);
+var maxOutputTokens = parsePositiveInt(MAX_OUTPUT_TOKENS, 6e3);
+var validReasoningEfforts = /* @__PURE__ */ new Set(["low", "medium", "high"]);
+var reasoningEffort = validReasoningEfforts.has(REASONING_EFFORT) ? REASONING_EFFORT : "medium";
 var failOn;
 try {
   const parsed = JSON.parse(FAIL_ON_SEVERITY);
@@ -17085,12 +17095,31 @@ function truncate(str2, n2) {
   if (str2.length <= n2) return str2;
   return str2.slice(0, n2) + "\n\n[...diff truncated for token safety...]";
 }
+function truncateWithMetadata(str2, n2) {
+  return {
+    text: truncate(str2, n2),
+    truncated: str2.length > n2,
+    originalChars: str2.length,
+    maxChars: n2
+  };
+}
+function parsePositiveInt(value, fallback) {
+  const parsed = parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
 function runGit(args, options = {}) {
   return (0, import_node_child_process.execFileSync)("git", args, {
     encoding: "utf8",
     cwd: options.cwd,
     stdio: ["ignore", "pipe", "pipe"]
   }).trimEnd();
+}
+function cleanInstructions(text, maxChars) {
+  return truncate(sanitizeDiff(text.trim()), maxChars);
+}
+function getReviewInstructions() {
+  const maxChars = parsePositiveInt(MAX_REVIEW_INSTRUCTIONS_CHARS, 12e3);
+  return REVIEW_INSTRUCTIONS.trim() ? cleanInstructions(REVIEW_INSTRUCTIONS, maxChars) : "";
 }
 var SENSITIVE_FILE_PATTERNS = [
   /(^|\/)\.env(\..*)?$/i,
@@ -17161,7 +17190,10 @@ function filterSafeFiles(files) {
   }
   if (excluded.length > 0) {
     console.log(`Excluded ${excluded.length} files from AI review:`);
-    excluded.forEach((reason) => console.log(`  - ${reason}`));
+    excluded.slice(0, 20).forEach((reason) => console.log(`  - ${reason}`));
+    if (excluded.length > 20) {
+      console.log(`  - ...and ${excluded.length - 20} more`);
+    }
   }
   console.log(`Including ${included.length} files in AI review`);
   return included;
@@ -17181,6 +17213,19 @@ function getLocalReviewContext() {
     title: `Local review for ${branchName}`,
     body: `Local AI review against base ref \`${baseRef}\` from branch \`${branchName}\`.`,
     diff: rawDiff,
+    diffMetadata: {
+      totalChangedFiles: changedFiles.length,
+      reviewedFiles: includedFileNames.length,
+      excludedFiles: changedFiles.length - includedFileNames.length,
+      fileListCapped: false,
+      maxReviewFiles: null,
+      oversizedFiles: [],
+      diffCappedByBuilder: false,
+      diffTruncated: false,
+      originalDiffChars: rawDiff.length,
+      maxDiffChars
+    },
+    reviewInstructions: getReviewInstructions(),
     workspaceDir: repoRoot,
     shouldPostComment: false,
     shouldUpdateCheck: false,
@@ -17203,11 +17248,13 @@ function sanitizeDiff(diffText) {
   });
   return sanitized;
 }
-function formatUnifiedPatch(files) {
+function formatUnifiedPatch(files, maxChars) {
   let out = "";
   let totalSize = 0;
-  const maxFileSize = 5e4;
-  const maxTotalSize = 15e4;
+  const maxFileSize = Math.min(25e3, maxChars);
+  const maxTotalSize = maxChars;
+  const oversizedFiles = [];
+  let diffCappedByBuilder = false;
   for (const f2 of files) {
     if (!f2.patch) continue;
     if (f2.patch.length > maxFileSize) {
@@ -17216,12 +17263,14 @@ function formatUnifiedPatch(files) {
 +++ b/${f2.filename}
 [File too large for review]
 `;
+      oversizedFiles.push(f2.filename);
       continue;
     }
     if (totalSize + f2.patch.length > maxTotalSize) {
       out += `
 [Additional files truncated for size]
 `;
+      diffCappedByBuilder = true;
       break;
     }
     out += `
@@ -17231,15 +17280,59 @@ ${f2.patch}
 `;
     totalSize += f2.patch.length;
   }
-  return out;
+  return {
+    diff: out,
+    metadata: {
+      oversizedFiles,
+      diffCappedByBuilder,
+      originalDiffChars: out.length,
+      maxDiffChars: maxChars
+    }
+  };
+}
+async function createReviewResponse(params) {
+  try {
+    return await openai.responses.create(params);
+  } catch (error) {
+    const message = `${error.message || ""} ${error.error?.message || ""}`;
+    const unsupportedFastOption = /reasoning|max_output_tokens|temperature|store/i.test(message) && /unsupported|unknown|invalid|not supported|unrecognized/i.test(message);
+    if (!unsupportedFastOption) throw error;
+    console.warn("Fast response options were not accepted by this model; retrying with compatibility options.");
+    const { reasoning, max_output_tokens, temperature, store, ...compatParams } = params;
+    return openai.responses.create(compatParams);
+  }
 }
 function escapeMarkdown(text) {
   return text.replace(/[[\\\]`*_{}()#+\-.!]/g, "\\$&");
 }
-function asMarkdown(review) {
+function formatDiffNotice(metadata) {
+  if (!metadata) return [];
+  const notices = [];
+  if (metadata.fileListCapped) {
+    notices.push(
+      `Only the first ${metadata.fetchedFiles || metadata.maxReviewFiles} of ${metadata.totalChangedFiles} changed files were fetched for review.`
+    );
+  }
+  if (metadata.diffCappedByBuilder || metadata.diffTruncated) {
+    notices.push(
+      `The diff was truncated to ${metadata.maxDiffChars} characters from ${metadata.originalDiffChars} characters.`
+    );
+  }
+  if (metadata.oversizedFiles?.length) {
+    notices.push(`${metadata.oversizedFiles.length} oversized file diff(s) were skipped.`);
+  }
+  return notices;
+}
+function asMarkdown(review, diffMetadata = null) {
   const lines = [];
   lines.push(`### \u{1F916} AI Code Review (${review.overall_risk.toUpperCase()})`);
   lines.push("");
+  const diffNotices = formatDiffNotice(diffMetadata);
+  if (diffNotices.length) {
+    lines.push("**Review coverage note:**");
+    diffNotices.forEach((notice) => lines.push(`- ${escapeMarkdown(notice)}`));
+    lines.push("");
+  }
   lines.push(escapeMarkdown(review.summary));
   lines.push("");
   if (!review.issues.length) {
@@ -17330,117 +17423,99 @@ function extractIssuesFromText(text) {
     issues
   };
 }
-function getReviewPrompt(prTitle, prBody, diff) {
-  const system = `You are reviewing a pull request by examining unified diffs. You ONLY see the changed lines, not the full codebase.
+var reviewResponseSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: ["summary", "overall_risk", "issues"],
+  properties: {
+    summary: {
+      type: "string",
+      description: "Brief encouraging summary of the review outcome."
+    },
+    overall_risk: {
+      type: "string",
+      enum: ["low", "medium", "high", "critical"]
+    },
+    issues: {
+      type: "array",
+      items: {
+        type: "object",
+        additionalProperties: false,
+        required: ["file", "line", "severity", "title", "detail", "suggestion", "tags"],
+        properties: {
+          file: { type: "string" },
+          line: {
+            type: ["integer", "null"]
+          },
+          severity: {
+            type: "string",
+            enum: ["info", "low", "medium", "high", "critical", "security"]
+          },
+          title: { type: "string" },
+          detail: { type: "string" },
+          suggestion: {
+            type: ["string", "null"]
+          },
+          tags: {
+            type: ["array", "null"],
+            items: { type: "string" }
+          }
+        }
+      }
+    }
+  }
+};
+function normalizeReview(parsed) {
+  const issues = Array.isArray(parsed.issues) ? parsed.issues : [];
+  return {
+    summary: typeof parsed.summary === "string" && parsed.summary.trim() ? parsed.summary.trim() : "AI review completed",
+    overall_risk: ["low", "medium", "high", "critical"].includes(parsed.overall_risk) ? parsed.overall_risk : "low",
+    issues: issues.filter((issue) => issue && typeof issue === "object").map((issue) => ({
+      file: typeof issue.file === "string" && issue.file.trim() ? issue.file.trim() : "unknown",
+      line: Number.isInteger(issue.line) ? issue.line : null,
+      severity: ["info", "low", "medium", "high", "critical", "security"].includes(issue.severity) ? issue.severity : "info",
+      title: typeof issue.title === "string" && issue.title.trim() ? issue.title.trim() : "Issue detected",
+      detail: typeof issue.detail === "string" && issue.detail.trim() ? issue.detail.trim() : "Issue detected in code review requiring attention.",
+      suggestion: typeof issue.suggestion === "string" && issue.suggestion.trim() ? issue.suggestion.trim() : null,
+      tags: Array.isArray(issue.tags) ? issue.tags.filter((tag) => typeof tag === "string") : null
+    }))
+  };
+}
+function parseReviewResponse(text) {
+  try {
+    return normalizeReview(JSON.parse(text));
+  } catch (error) {
+    console.warn("Structured review JSON parse failed, falling back to text parser:", error.message);
+    return extractIssuesFromText(text);
+  }
+}
+function getReviewPrompt(prTitle, prBody, diff, reviewInstructions = "") {
+  const system = `Review this pull request from unified diffs only. Assume type checks, linting, and formatting already passed.
 
-CRITICAL CONTEXT:
-- \u26A0\uFE0F IMPORTANT: This code has ALREADY PASSED type checking (TypeScript/Flow/etc.) and linting (ESLint/TSLint/etc.)
-  * All type errors have been resolved - DO NOT flag type-related issues
-  * All linting errors have been resolved - DO NOT flag style, formatting, or linting issues
-  * If something compiles and passes lint, assume it's correct from a static analysis perspective
-- You only see DIFFS (changed lines), not complete files. This means:
-  * Imports/types may exist elsewhere - DO NOT flag "missing imports" or "undefined types"
-  * Existing code patterns and context are not visible to you
-  * Assume standard tooling (TypeScript, ESLint, etc.) already handles static analysis
-- Other tools are running: type checkers, linters, formatters already catch most issues
-- Your role: Find logic bugs, security vulnerabilities, and critical errors that slip through other tools
+Flag only high-confidence issues that can cause production bugs, security exposure, data loss/corruption, crashes, or clear runtime/build failures visible in the diff.
 
-GOAL: Find REAL bugs and security vulnerabilities that would cause runtime failures or data breaches.
+Good findings include:
+- Logic errors, wrong conditions, off-by-one mistakes, race/resource problems, infinite loops, and serious performance hotspots.
+- SQL/NoSQL injection, XSS, hardcoded secrets, insecure randomness, auth/authz bypasses, and unsafe trust boundaries.
+- Critical missing validation/error handling only when it can corrupt data, expose data, or crash an important path.
+- Missing imports/undefined symbols only when the changed lines clearly introduce a new symbol that is not imported, declared, auto-imported, globally available, or namespace-qualified.
+- Repo convention violations only when the repo-specific instructions explicitly say they matter.
 
-COMPLETENESS REQUIREMENTS:
-- Review the ENTIRE diff before finalizing your answer.
-- Return the most complete set of distinct findings you can identify in this pass.
-- Do NOT stop after finding the first serious issue; continue checking the remaining files for additional independent issues.
-- Do NOT intentionally hold back issues for future runs.
-- If multiple observations stem from the same root cause, combine them into one finding with the clearest file/line reference.
-- Favor consistency across reruns: if the same diff is reviewed again, the findings list should stay as stable and comprehensive as possible.
+Do not report style, formatting, naming, missing tests/docs, refactors, theoretical risks, type-only issues, unused code, or anything standard linters/type checkers should catch.
 
-WHAT TO FLAG (only if you're 95%+ confident):
-\u2705 Runtime bugs that would break in production:
-   - Logic errors causing incorrect behavior (off-by-one, wrong conditions)
-   - Race conditions or concurrency issues
-   - Memory leaks or resource exhaustion
-   - Infinite loops or performance hotspots (NOT micro-optimizations)
+Use conservative severities:
+- security: active vulnerability or data exposure.
+- critical: immediate production failure or data loss.
+- high: serious incorrect behavior or likely crash.
+- medium: intermittent failure or degraded functionality.
+- low/info: rare edge cases or useful non-blocking observations.
 
-\u2705 Security vulnerabilities (actual, not theoretical):
-   - SQL injection (user input concatenated into queries)
-   - XSS vulnerabilities (unsanitized user input in HTML/JS)
-   - Hardcoded secrets, passwords, API keys
-   - Insecure random number generation (crypto)
-   - Authorization bypasses (missing permission checks)
+Prefer repo-specific instructions over generic assumptions. Combine duplicate root causes. Return all distinct high-confidence findings, or an empty issues array if the diff looks safe. Return only JSON matching the schema.`;
+  const repoContext = reviewInstructions ? `
 
-\u2705 Critical error handling gaps:
-   - Unhandled exceptions that would crash the application
-   - Missing validation that could corrupt data
-
-\u274C DO NOT FLAG (these are handled by type checkers and linters):
-   - Type errors, type mismatches, or "any" types (TypeScript already checked this)
-   - Missing type annotations or type definitions (type checker handles this)
-   - Type narrowing issues or type guards (type checker validates this)
-   - Missing imports, types, or "undefined" references (they exist elsewhere and type checker verified)
-   - Unused variables, imports, or dead code (linter catches this)
-   - Code style, formatting, indentation, spacing (linter/formatter handles this)
-   - Naming conventions, variable naming, function naming (linter enforces this)
-   - Missing semicolons, trailing commas, quote style (linter/formatter fixes this)
-   - Missing return type annotations (type checker infers and validates)
-   - Generic type parameters or type constraints (type checker validates)
-   - Missing tests or documentation
-   - Code complexity or refactoring suggestions
-   - Theoretical security concerns ("could potentially")
-   - Config files or build artifacts
-   - Redacted values like [REDACTED_AWS_KEY]
-   - Architectural patterns or design choices
-   - Missing error handling for edge cases (only flag critical gaps)
-   - Performance micro-optimizations
-   - "Consider adding..." or "might want to..." suggestions
-   - Issues that would be caught by ESLint, TSLint, Prettier, or similar tools
-
-SEVERITY GUIDELINES (use conservatively):
-[SECURITY] - Active vulnerability that allows unauthorized access or data breach
-  Examples: SQL injection, XSS, hardcoded secrets, auth bypass
-  
-[CRITICAL] - Bug that would cause immediate production failure or data loss
-  Examples: Null pointer in critical path, infinite loop, memory exhaustion
-  
-[HIGH] - Serious bug that causes incorrect behavior or frequent crashes
-  Examples: Logic error causing wrong results, missing validation causing data corruption
-  
-[MEDIUM] - Bug that causes occasional failures or degraded functionality
-  Examples: Race condition causing intermittent issues, resource leak
-  
-[LOW] - Minor issue that may cause problems in edge cases
-  Examples: Potential null dereference in rarely-executed path
-
-[INFO] - Rarely use - only for genuinely helpful suggestions, not required fixes
-
-TONE: Assume competence. The code has passed type checking and linting - trust that static analysis tools have done their job. If you're not CERTAIN something is a runtime bug or security vulnerability, don't report it. False positives for lint/type issues waste time and erode trust.
-
-FINAL SELF-CHECK BEFORE ANSWERING:
-- Re-scan the diff one more time for any additional distinct runtime or security issues you may have missed.
-- Ensure the final answer includes all issues you are confident about from this review pass.
-- Ensure each finding is specific, actionable, and non-duplicative.
-
-RESPONSE FORMAT: Provide your review in plain text with the following structure:
-
-OVERALL RISK: LOW|MEDIUM|HIGH|CRITICAL
-
-Brief, encouraging summary of the code review.
-
-For each issue found, use this format:
-[SEVERITY] Issue Title - path/to/file.js:123
-Detailed explanation of the issue.
-Suggestion: Actionable suggestion to fix the issue.
-
-Example:
-OVERALL RISK: LOW
-
-Great work! The code changes look solid.
-
-[SECURITY] SQL Injection Vulnerability - src/api/users.js:45
-User input from req.body.id is directly concatenated into SQL query: "SELECT * FROM users WHERE id = " + req.body.id
-Suggestion: Use parameterized queries: "SELECT * FROM users WHERE id = ?" with prepared statement parameters.
-
-If everything looks good, just provide a positive summary with "OVERALL RISK: LOW" and no issue markers.`;
+Repository-specific review instructions:
+${reviewInstructions}
+` : "";
   const user = `Pull Request Title: ${prTitle}
 
 Pull Request Description:
@@ -17449,7 +17524,7 @@ ${prBody}
 Unified Diff (truncated if large):
 ${diff}
 `;
-  return `${system}
+  return `${system}${repoContext}
 
 User Request:
 ${user}`;
@@ -17460,7 +17535,7 @@ function printLocalJsonReport(report) {
   console.log("AI_REVIEW_JSON_END");
 }
 function printLocalSummary(parsed, reportPath, report = null) {
-  console.log(asMarkdown(parsed));
+  console.log(asMarkdown(parsed, report?.diff_metadata));
   console.log("");
   console.log(`Report: ${reportPath}`);
   if (report) {
@@ -17475,17 +17550,37 @@ function printLocalSummary(parsed, reportPath, report = null) {
       reviewContext = getLocalReviewContext();
     } else {
       const { data: pr2 } = await octo.pulls.get({ owner, repo, pull_number: prNumber });
-      const files = await octo.paginate(octo.pulls.listFiles, {
+      const { data: files } = await octo.pulls.listFiles({
         owner,
         repo,
         pull_number: prNumber,
-        per_page: 100
+        per_page: maxReviewFiles
       });
+      const changedFilesCount = pr2.changed_files ?? files.length;
+      const fileListCapped = changedFilesCount > files.length;
+      if (fileListCapped) {
+        console.log(`Review file list capped at ${maxReviewFiles} files for speed.`);
+      }
       const safeFiles = filterSafeFiles(files);
+      const patch = formatUnifiedPatch(safeFiles, maxDiffChars);
       reviewContext = {
         title: pr2.title || "",
         body: pr2.body || "",
-        diff: formatUnifiedPatch(safeFiles),
+        diff: patch.diff,
+        diffMetadata: {
+          totalChangedFiles: changedFilesCount,
+          fetchedFiles: files.length,
+          reviewedFiles: safeFiles.length,
+          excludedFiles: files.length - safeFiles.length,
+          fileListCapped,
+          maxReviewFiles,
+          oversizedFiles: patch.metadata.oversizedFiles,
+          diffCappedByBuilder: patch.metadata.diffCappedByBuilder,
+          diffTruncated: false,
+          originalDiffChars: patch.metadata.originalDiffChars,
+          maxDiffChars
+        },
+        reviewInstructions: getReviewInstructions(),
         workspaceDir: process.env.GITHUB_WORKSPACE || process.cwd(),
         shouldPostComment: true,
         shouldUpdateCheck: true,
@@ -17493,7 +17588,17 @@ function printLocalSummary(parsed, reportPath, report = null) {
       };
     }
     const redactedDiff = sanitizeDiff(reviewContext.diff);
-    const diff = truncate(redactedDiff, parseInt(MAX_DIFF_CHARS, 10));
+    const truncatedDiff = truncateWithMetadata(redactedDiff, maxDiffChars);
+    const diff = truncatedDiff.text;
+    const diffMetadata = {
+      ...reviewContext.diffMetadata,
+      diffTruncated: reviewContext.diffMetadata?.diffTruncated || truncatedDiff.truncated,
+      originalDiffChars: Math.max(
+        reviewContext.diffMetadata?.originalDiffChars || 0,
+        truncatedDiff.originalChars
+      ),
+      maxDiffChars
+    };
     if (!diff.trim()) {
       const parsed2 = {
         summary: "No reviewable code changes were found in the current diff.",
@@ -17507,7 +17612,8 @@ function printLocalSummary(parsed, reportPath, report = null) {
         parsed: parsed2,
         timestamp: (/* @__PURE__ */ new Date()).toISOString(),
         model: AI_MODEL,
-        mode: isLocalMode ? "local" : "github-action"
+        mode: isLocalMode ? "local" : "github-action",
+        diff_metadata: diffMetadata
       };
       import_node_fs2.default.writeFileSync(reportPath2, JSON.stringify(fullReport2, null, 2));
       if (isLocalMode) {
@@ -17518,24 +17624,34 @@ function printLocalSummary(parsed, reportPath, report = null) {
       process.exit(0);
     }
     console.log("\u{1F916} AI Model being used:", AI_MODEL);
-    console.log("\u{1F504} Using responses API for plain text output...");
-    const ai = await openai.responses.create({
+    if (reviewContext.reviewInstructions) {
+      console.log("\u{1F4DA} Loaded repository-specific review instructions");
+    }
+    console.log("\u{1F504} Using responses API with structured review output...");
+    const ai = await createReviewResponse({
       model: AI_MODEL,
-      input: getReviewPrompt(reviewContext.title, reviewContext.body, diff),
-      temperature: 0
-      // No response_format specified = plain text output
+      input: getReviewPrompt(reviewContext.title, reviewContext.body, diff, reviewContext.reviewInstructions),
+      temperature: 0,
+      max_output_tokens: maxOutputTokens,
+      reasoning: { effort: reasoningEffort },
+      store: false,
+      text: {
+        format: {
+          type: "json_schema",
+          name: "ai_code_review",
+          strict: true,
+          schema: reviewResponseSchema
+        }
+      }
     });
     console.log("\u2705 Responses API call succeeded");
-    console.log("\u{1F50D} Full AI response structure:", JSON.stringify(ai, null, 2));
     const text = ai.output_text || ai.response?.content || ai.content;
     if (!text || text.trim() === "") {
       console.error("\u274C AI returned empty response");
-      console.error("\u274C Response structure:", JSON.stringify(ai, null, 2));
       throw new Error("AI returned empty response");
     }
     console.log("\u{1F4DD} AI Response length:", text.length);
-    console.log("\u{1F4DD} AI Response preview:", text.substring(0, 500));
-    const parsed = extractIssuesFromText(text);
+    const parsed = parseReviewResponse(text);
     console.log("\u2705 Successfully parsed AI response");
     console.log(`\u{1F4CA} Found ${parsed.issues.length} issues with overall risk: ${parsed.overall_risk}`);
     const workspaceDir = reviewContext.workspaceDir;
@@ -17546,7 +17662,8 @@ function printLocalSummary(parsed, reportPath, report = null) {
       parsed,
       timestamp: (/* @__PURE__ */ new Date()).toISOString(),
       model: AI_MODEL,
-      mode: isLocalMode ? "local" : "github-action"
+      mode: isLocalMode ? "local" : "github-action",
+      diff_metadata: diffMetadata
     };
     import_node_fs2.default.writeFileSync(reportPath, JSON.stringify(fullReport, null, 2));
     console.log(`AI review report written to: ${reportPath}`);
@@ -17558,7 +17675,7 @@ function printLocalSummary(parsed, reportPath, report = null) {
     if (reviewContext.shouldPostComment) {
       const marker = "<!-- ai-code-review-bot -->";
       const bodyMd = `${marker}
-${asMarkdown(parsed)}
+${asMarkdown(parsed, diffMetadata)}
 ${marker}`;
       const allComments = await octo.paginate(octo.issues.listComments, {
         owner,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "ai-code-review-github-action",
-    "version": "1.2.2",
+    "version": "1.2.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "ai-code-review-github-action",
-            "version": "1.2.2",
+            "version": "1.2.4",
             "license": "MIT",
             "dependencies": {
                 "@octokit/rest": "^20.0.2",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
     "name": "ai-code-review-github-action",
-    "version": "1.2.3",
+    "version": "1.2.4",
     "description": "AI-powered code review GitHub Action",
     "main": "src/review.js",
     "scripts": {
         "review:local": "node src/review.js --local",
-        "build": "esbuild src/review.js --bundle --platform=node --target=node22 --format=cjs --outfile=dist/index.js --banner:js=\"#!/usr/bin/env node\" --external:node:fs --external:node:path --external:node:stream --external:node:util --external:node:crypto --external:node:http --external:node:https --external:node:url --external:node:os --external:node:child_process",
+        "build": "esbuild src/review.js --bundle --platform=node --target=node20 --format=cjs --outfile=dist/index.js --banner:js=\"#!/usr/bin/env node\" --external:node:fs --external:node:path --external:node:stream --external:node:util --external:node:crypto --external:node:http --external:node:https --external:node:url --external:node:os --external:node:child_process",
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "dependencies": {

--- a/src/review.js
+++ b/src/review.js
@@ -10,9 +10,14 @@ const {
   INPUT_GITHUB_TOKEN: GITHUB_TOKEN,
   INPUT_OPENAI_API_KEY,
   OPENAI_API_KEY,
-  INPUT_AI_MODEL: AI_MODEL = 'gpt-5-mini',
+  INPUT_AI_MODEL: AI_MODEL = 'gpt-5.5',
   INPUT_MAX_DIFF_CHARS: MAX_DIFF_CHARS = '180000',
+  INPUT_MAX_REVIEW_FILES: MAX_REVIEW_FILES = '100',
+  INPUT_MAX_OUTPUT_TOKENS: MAX_OUTPUT_TOKENS = '6000',
+  INPUT_REASONING_EFFORT: REASONING_EFFORT = 'medium',
   INPUT_FAIL_ON_SEVERITY: FAIL_ON_SEVERITY = '["high","critical","security"]',
+  INPUT_REVIEW_INSTRUCTIONS: REVIEW_INSTRUCTIONS = '',
+  INPUT_MAX_REVIEW_INSTRUCTIONS_CHARS: MAX_REVIEW_INSTRUCTIONS_CHARS = '12000',
   GITHUB_REPOSITORY,
 } = process.env
 
@@ -54,6 +59,11 @@ if (!isLocalMode && !Number.isInteger(prNumber)) {
 
 const octo = isLocalMode ? null : new Octokit({ auth: GITHUB_TOKEN })
 const openai = new OpenAI({ apiKey: REVIEW_OPENAI_API_KEY })
+const maxDiffChars = parsePositiveInt(MAX_DIFF_CHARS, 180000)
+const maxReviewFiles = Math.min(parsePositiveInt(MAX_REVIEW_FILES, 100), 100)
+const maxOutputTokens = parsePositiveInt(MAX_OUTPUT_TOKENS, 6000)
+const validReasoningEfforts = new Set(['low', 'medium', 'high'])
+const reasoningEffort = validReasoningEfforts.has(REASONING_EFFORT) ? REASONING_EFFORT : 'medium'
 
 let failOn
 try {
@@ -78,12 +88,35 @@ function truncate(str, n) {
   return str.slice(0, n) + '\n\n[...diff truncated for token safety...]'
 }
 
+function truncateWithMetadata(str, n) {
+  return {
+    text: truncate(str, n),
+    truncated: str.length > n,
+    originalChars: str.length,
+    maxChars: n,
+  }
+}
+
+function parsePositiveInt(value, fallback) {
+  const parsed = parseInt(value, 10)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
+}
+
 function runGit(args, options = {}) {
   return execFileSync('git', args, {
     encoding: 'utf8',
     cwd: options.cwd,
     stdio: ['ignore', 'pipe', 'pipe'],
   }).trimEnd()
+}
+
+function cleanInstructions(text, maxChars) {
+  return truncate(sanitizeDiff(text.trim()), maxChars)
+}
+
+function getReviewInstructions() {
+  const maxChars = parsePositiveInt(MAX_REVIEW_INSTRUCTIONS_CHARS, 12000)
+  return REVIEW_INSTRUCTIONS.trim() ? cleanInstructions(REVIEW_INSTRUCTIONS, maxChars) : ''
 }
 
 // Exclude obviously sensitive files and paths from being sent to AI
@@ -169,7 +202,10 @@ function filterSafeFiles(files) {
   // Log excluded files for auditability
   if (excluded.length > 0) {
     console.log(`Excluded ${excluded.length} files from AI review:`)
-    excluded.forEach(reason => console.log(`  - ${reason}`))
+    excluded.slice(0, 20).forEach(reason => console.log(`  - ${reason}`))
+    if (excluded.length > 20) {
+      console.log(`  - ...and ${excluded.length - 20} more`)
+    }
   }
 
   console.log(`Including ${included.length} files in AI review`)
@@ -199,6 +235,19 @@ function getLocalReviewContext() {
     title: `Local review for ${branchName}`,
     body: `Local AI review against base ref \`${baseRef}\` from branch \`${branchName}\`.`,
     diff: rawDiff,
+    diffMetadata: {
+      totalChangedFiles: changedFiles.length,
+      reviewedFiles: includedFileNames.length,
+      excludedFiles: changedFiles.length - includedFileNames.length,
+      fileListCapped: false,
+      maxReviewFiles: null,
+      oversizedFiles: [],
+      diffCappedByBuilder: false,
+      diffTruncated: false,
+      originalDiffChars: rawDiff.length,
+      maxDiffChars,
+    },
+    reviewInstructions: getReviewInstructions(),
     workspaceDir: repoRoot,
     shouldPostComment: false,
     shouldUpdateCheck: false,
@@ -236,27 +285,56 @@ function sanitizeDiff(diffText) {
   return sanitized
 }
 
-function formatUnifiedPatch(files) {
+function formatUnifiedPatch(files, maxChars) {
   // GitHub's listFiles returns `patch` (unified diff) per file; concatenate safely.
   let out = ''
   let totalSize = 0
-  const maxFileSize = 50000 // Skip very large files
-  const maxTotalSize = 150000 // Stop before hitting memory issues
+  const maxFileSize = Math.min(25000, maxChars)
+  const maxTotalSize = maxChars
+  const oversizedFiles = []
+  let diffCappedByBuilder = false
 
   for (const f of files) {
     if (!f.patch) continue
     if (f.patch.length > maxFileSize) {
       out += `\n--- a/${f.filename}\n+++ b/${f.filename}\n[File too large for review]\n`
+      oversizedFiles.push(f.filename)
       continue
     }
     if (totalSize + f.patch.length > maxTotalSize) {
       out += `\n[Additional files truncated for size]\n`
+      diffCappedByBuilder = true
       break
     }
     out += `\n--- a/${f.filename}\n+++ b/${f.filename}\n${f.patch}\n`
     totalSize += f.patch.length
   }
-  return out
+  return {
+    diff: out,
+    metadata: {
+      oversizedFiles,
+      diffCappedByBuilder,
+      originalDiffChars: out.length,
+      maxDiffChars: maxChars,
+    },
+  }
+}
+
+async function createReviewResponse(params) {
+  try {
+    return await openai.responses.create(params)
+  } catch (error) {
+    const message = `${error.message || ''} ${error.error?.message || ''}`
+    const unsupportedFastOption =
+      /reasoning|max_output_tokens|temperature|store/i.test(message) &&
+      /unsupported|unknown|invalid|not supported|unrecognized/i.test(message)
+
+    if (!unsupportedFastOption) throw error
+
+    console.warn('Fast response options were not accepted by this model; retrying with compatibility options.')
+    const { reasoning, max_output_tokens, temperature, store, ...compatParams } = params
+    return openai.responses.create(compatParams)
+  }
 }
 
 function escapeMarkdown(text) {
@@ -264,10 +342,37 @@ function escapeMarkdown(text) {
   return text.replace(/[[\\\]`*_{}()#+\-.!]/g, '\\$&')
 }
 
-function asMarkdown(review) {
+function formatDiffNotice(metadata) {
+  if (!metadata) return []
+
+  const notices = []
+  if (metadata.fileListCapped) {
+    notices.push(
+      `Only the first ${metadata.fetchedFiles || metadata.maxReviewFiles} of ${metadata.totalChangedFiles} changed files were fetched for review.`,
+    )
+  }
+  if (metadata.diffCappedByBuilder || metadata.diffTruncated) {
+    notices.push(
+      `The diff was truncated to ${metadata.maxDiffChars} characters from ${metadata.originalDiffChars} characters.`,
+    )
+  }
+  if (metadata.oversizedFiles?.length) {
+    notices.push(`${metadata.oversizedFiles.length} oversized file diff(s) were skipped.`)
+  }
+
+  return notices
+}
+
+function asMarkdown(review, diffMetadata = null) {
   const lines = []
   lines.push(`### 🤖 AI Code Review (${review.overall_risk.toUpperCase()})`)
   lines.push('')
+  const diffNotices = formatDiffNotice(diffMetadata)
+  if (diffNotices.length) {
+    lines.push('**Review coverage note:**')
+    diffNotices.forEach(notice => lines.push(`- ${escapeMarkdown(notice)}`))
+    lines.push('')
+  }
   lines.push(escapeMarkdown(review.summary))
   lines.push('')
   if (!review.issues.length) {
@@ -389,117 +494,115 @@ function extractIssuesFromText(text) {
   }
 }
 
-function getReviewPrompt(prTitle, prBody, diff) {
-  const system = `You are reviewing a pull request by examining unified diffs. You ONLY see the changed lines, not the full codebase.
+const reviewResponseSchema = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['summary', 'overall_risk', 'issues'],
+  properties: {
+    summary: {
+      type: 'string',
+      description: 'Brief encouraging summary of the review outcome.',
+    },
+    overall_risk: {
+      type: 'string',
+      enum: ['low', 'medium', 'high', 'critical'],
+    },
+    issues: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['file', 'line', 'severity', 'title', 'detail', 'suggestion', 'tags'],
+        properties: {
+          file: { type: 'string' },
+          line: {
+            type: ['integer', 'null'],
+          },
+          severity: {
+            type: 'string',
+            enum: ['info', 'low', 'medium', 'high', 'critical', 'security'],
+          },
+          title: { type: 'string' },
+          detail: { type: 'string' },
+          suggestion: {
+            type: ['string', 'null'],
+          },
+          tags: {
+            type: ['array', 'null'],
+            items: { type: 'string' },
+          },
+        },
+      },
+    },
+  },
+}
 
-CRITICAL CONTEXT:
-- ⚠️ IMPORTANT: This code has ALREADY PASSED type checking (TypeScript/Flow/etc.) and linting (ESLint/TSLint/etc.)
-  * All type errors have been resolved - DO NOT flag type-related issues
-  * All linting errors have been resolved - DO NOT flag style, formatting, or linting issues
-  * If something compiles and passes lint, assume it's correct from a static analysis perspective
-- You only see DIFFS (changed lines), not complete files. This means:
-  * Imports/types may exist elsewhere - DO NOT flag "missing imports" or "undefined types"
-  * Existing code patterns and context are not visible to you
-  * Assume standard tooling (TypeScript, ESLint, etc.) already handles static analysis
-- Other tools are running: type checkers, linters, formatters already catch most issues
-- Your role: Find logic bugs, security vulnerabilities, and critical errors that slip through other tools
+function normalizeReview(parsed) {
+  const issues = Array.isArray(parsed.issues) ? parsed.issues : []
+  return {
+    summary: typeof parsed.summary === 'string' && parsed.summary.trim()
+      ? parsed.summary.trim()
+      : 'AI review completed',
+    overall_risk: ['low', 'medium', 'high', 'critical'].includes(parsed.overall_risk)
+      ? parsed.overall_risk
+      : 'low',
+    issues: issues
+      .filter(issue => issue && typeof issue === 'object')
+      .map(issue => ({
+        file: typeof issue.file === 'string' && issue.file.trim() ? issue.file.trim() : 'unknown',
+        line: Number.isInteger(issue.line) ? issue.line : null,
+        severity: ['info', 'low', 'medium', 'high', 'critical', 'security'].includes(issue.severity)
+          ? issue.severity
+          : 'info',
+        title: typeof issue.title === 'string' && issue.title.trim()
+          ? issue.title.trim()
+          : 'Issue detected',
+        detail: typeof issue.detail === 'string' && issue.detail.trim()
+          ? issue.detail.trim()
+          : 'Issue detected in code review requiring attention.',
+        suggestion: typeof issue.suggestion === 'string' && issue.suggestion.trim()
+          ? issue.suggestion.trim()
+          : null,
+        tags: Array.isArray(issue.tags) ? issue.tags.filter(tag => typeof tag === 'string') : null,
+      })),
+  }
+}
 
-GOAL: Find REAL bugs and security vulnerabilities that would cause runtime failures or data breaches.
+function parseReviewResponse(text) {
+  try {
+    return normalizeReview(JSON.parse(text))
+  } catch (error) {
+    console.warn('Structured review JSON parse failed, falling back to text parser:', error.message)
+    return extractIssuesFromText(text)
+  }
+}
 
-COMPLETENESS REQUIREMENTS:
-- Review the ENTIRE diff before finalizing your answer.
-- Return the most complete set of distinct findings you can identify in this pass.
-- Do NOT stop after finding the first serious issue; continue checking the remaining files for additional independent issues.
-- Do NOT intentionally hold back issues for future runs.
-- If multiple observations stem from the same root cause, combine them into one finding with the clearest file/line reference.
-- Favor consistency across reruns: if the same diff is reviewed again, the findings list should stay as stable and comprehensive as possible.
+function getReviewPrompt(prTitle, prBody, diff, reviewInstructions = '') {
+  const system = `Review this pull request from unified diffs only. Assume type checks, linting, and formatting already passed.
 
-WHAT TO FLAG (only if you're 95%+ confident):
-✅ Runtime bugs that would break in production:
-   - Logic errors causing incorrect behavior (off-by-one, wrong conditions)
-   - Race conditions or concurrency issues
-   - Memory leaks or resource exhaustion
-   - Infinite loops or performance hotspots (NOT micro-optimizations)
+Flag only high-confidence issues that can cause production bugs, security exposure, data loss/corruption, crashes, or clear runtime/build failures visible in the diff.
 
-✅ Security vulnerabilities (actual, not theoretical):
-   - SQL injection (user input concatenated into queries)
-   - XSS vulnerabilities (unsanitized user input in HTML/JS)
-   - Hardcoded secrets, passwords, API keys
-   - Insecure random number generation (crypto)
-   - Authorization bypasses (missing permission checks)
+Good findings include:
+- Logic errors, wrong conditions, off-by-one mistakes, race/resource problems, infinite loops, and serious performance hotspots.
+- SQL/NoSQL injection, XSS, hardcoded secrets, insecure randomness, auth/authz bypasses, and unsafe trust boundaries.
+- Critical missing validation/error handling only when it can corrupt data, expose data, or crash an important path.
+- Missing imports/undefined symbols only when the changed lines clearly introduce a new symbol that is not imported, declared, auto-imported, globally available, or namespace-qualified.
+- Repo convention violations only when the repo-specific instructions explicitly say they matter.
 
-✅ Critical error handling gaps:
-   - Unhandled exceptions that would crash the application
-   - Missing validation that could corrupt data
+Do not report style, formatting, naming, missing tests/docs, refactors, theoretical risks, type-only issues, unused code, or anything standard linters/type checkers should catch.
 
-❌ DO NOT FLAG (these are handled by type checkers and linters):
-   - Type errors, type mismatches, or "any" types (TypeScript already checked this)
-   - Missing type annotations or type definitions (type checker handles this)
-   - Type narrowing issues or type guards (type checker validates this)
-   - Missing imports, types, or "undefined" references (they exist elsewhere and type checker verified)
-   - Unused variables, imports, or dead code (linter catches this)
-   - Code style, formatting, indentation, spacing (linter/formatter handles this)
-   - Naming conventions, variable naming, function naming (linter enforces this)
-   - Missing semicolons, trailing commas, quote style (linter/formatter fixes this)
-   - Missing return type annotations (type checker infers and validates)
-   - Generic type parameters or type constraints (type checker validates)
-   - Missing tests or documentation
-   - Code complexity or refactoring suggestions
-   - Theoretical security concerns ("could potentially")
-   - Config files or build artifacts
-   - Redacted values like [REDACTED_AWS_KEY]
-   - Architectural patterns or design choices
-   - Missing error handling for edge cases (only flag critical gaps)
-   - Performance micro-optimizations
-   - "Consider adding..." or "might want to..." suggestions
-   - Issues that would be caught by ESLint, TSLint, Prettier, or similar tools
+Use conservative severities:
+- security: active vulnerability or data exposure.
+- critical: immediate production failure or data loss.
+- high: serious incorrect behavior or likely crash.
+- medium: intermittent failure or degraded functionality.
+- low/info: rare edge cases or useful non-blocking observations.
 
-SEVERITY GUIDELINES (use conservatively):
-[SECURITY] - Active vulnerability that allows unauthorized access or data breach
-  Examples: SQL injection, XSS, hardcoded secrets, auth bypass
-  
-[CRITICAL] - Bug that would cause immediate production failure or data loss
-  Examples: Null pointer in critical path, infinite loop, memory exhaustion
-  
-[HIGH] - Serious bug that causes incorrect behavior or frequent crashes
-  Examples: Logic error causing wrong results, missing validation causing data corruption
-  
-[MEDIUM] - Bug that causes occasional failures or degraded functionality
-  Examples: Race condition causing intermittent issues, resource leak
-  
-[LOW] - Minor issue that may cause problems in edge cases
-  Examples: Potential null dereference in rarely-executed path
+Prefer repo-specific instructions over generic assumptions. Combine duplicate root causes. Return all distinct high-confidence findings, or an empty issues array if the diff looks safe. Return only JSON matching the schema.`
 
-[INFO] - Rarely use - only for genuinely helpful suggestions, not required fixes
-
-TONE: Assume competence. The code has passed type checking and linting - trust that static analysis tools have done their job. If you're not CERTAIN something is a runtime bug or security vulnerability, don't report it. False positives for lint/type issues waste time and erode trust.
-
-FINAL SELF-CHECK BEFORE ANSWERING:
-- Re-scan the diff one more time for any additional distinct runtime or security issues you may have missed.
-- Ensure the final answer includes all issues you are confident about from this review pass.
-- Ensure each finding is specific, actionable, and non-duplicative.
-
-RESPONSE FORMAT: Provide your review in plain text with the following structure:
-
-OVERALL RISK: LOW|MEDIUM|HIGH|CRITICAL
-
-Brief, encouraging summary of the code review.
-
-For each issue found, use this format:
-[SEVERITY] Issue Title - path/to/file.js:123
-Detailed explanation of the issue.
-Suggestion: Actionable suggestion to fix the issue.
-
-Example:
-OVERALL RISK: LOW
-
-Great work! The code changes look solid.
-
-[SECURITY] SQL Injection Vulnerability - src/api/users.js:45
-User input from req.body.id is directly concatenated into SQL query: "SELECT * FROM users WHERE id = " + req.body.id
-Suggestion: Use parameterized queries: "SELECT * FROM users WHERE id = ?" with prepared statement parameters.
-
-If everything looks good, just provide a positive summary with "OVERALL RISK: LOW" and no issue markers.`
+  const repoContext = reviewInstructions
+    ? `\n\nRepository-specific review instructions:\n${reviewInstructions}\n`
+    : ''
 
   const user = `Pull Request Title: ${prTitle}
 
@@ -510,7 +613,7 @@ Unified Diff (truncated if large):
 ${diff}
 `
 
-  return `${system}\n\nUser Request:\n${user}`
+  return `${system}${repoContext}\n\nUser Request:\n${user}`
 }
 
 function printLocalJsonReport(report) {
@@ -520,7 +623,7 @@ function printLocalJsonReport(report) {
 }
 
 function printLocalSummary(parsed, reportPath, report = null) {
-  console.log(asMarkdown(parsed))
+  console.log(asMarkdown(parsed, report?.diff_metadata))
   console.log('')
   console.log(`Report: ${reportPath}`)
   if (report) {
@@ -536,17 +639,37 @@ function printLocalSummary(parsed, reportPath, report = null) {
       reviewContext = getLocalReviewContext()
     } else {
       const { data: pr } = await octo.pulls.get({ owner, repo, pull_number: prNumber })
-      const files = await octo.paginate(octo.pulls.listFiles, {
+      const { data: files } = await octo.pulls.listFiles({
         owner,
         repo,
         pull_number: prNumber,
-        per_page: 100,
+        per_page: maxReviewFiles,
       })
+      const changedFilesCount = pr.changed_files ?? files.length
+      const fileListCapped = changedFilesCount > files.length
+      if (fileListCapped) {
+        console.log(`Review file list capped at ${maxReviewFiles} files for speed.`)
+      }
       const safeFiles = filterSafeFiles(files)
+      const patch = formatUnifiedPatch(safeFiles, maxDiffChars)
       reviewContext = {
         title: pr.title || '',
         body: pr.body || '',
-        diff: formatUnifiedPatch(safeFiles),
+        diff: patch.diff,
+        diffMetadata: {
+          totalChangedFiles: changedFilesCount,
+          fetchedFiles: files.length,
+          reviewedFiles: safeFiles.length,
+          excludedFiles: files.length - safeFiles.length,
+          fileListCapped,
+          maxReviewFiles,
+          oversizedFiles: patch.metadata.oversizedFiles,
+          diffCappedByBuilder: patch.metadata.diffCappedByBuilder,
+          diffTruncated: false,
+          originalDiffChars: patch.metadata.originalDiffChars,
+          maxDiffChars,
+        },
+        reviewInstructions: getReviewInstructions(),
         workspaceDir: process.env.GITHUB_WORKSPACE || process.cwd(),
         shouldPostComment: true,
         shouldUpdateCheck: true,
@@ -555,7 +678,17 @@ function printLocalSummary(parsed, reportPath, report = null) {
     }
 
     const redactedDiff = sanitizeDiff(reviewContext.diff)
-    const diff = truncate(redactedDiff, parseInt(MAX_DIFF_CHARS, 10))
+    const truncatedDiff = truncateWithMetadata(redactedDiff, maxDiffChars)
+    const diff = truncatedDiff.text
+    const diffMetadata = {
+      ...reviewContext.diffMetadata,
+      diffTruncated: reviewContext.diffMetadata?.diffTruncated || truncatedDiff.truncated,
+      originalDiffChars: Math.max(
+        reviewContext.diffMetadata?.originalDiffChars || 0,
+        truncatedDiff.originalChars,
+      ),
+      maxDiffChars,
+    }
 
     if (!diff.trim()) {
       const parsed = {
@@ -571,6 +704,7 @@ function printLocalSummary(parsed, reportPath, report = null) {
         timestamp: new Date().toISOString(),
         model: AI_MODEL,
         mode: isLocalMode ? 'local' : 'github-action',
+        diff_metadata: diffMetadata,
       }
       fs.writeFileSync(reportPath, JSON.stringify(fullReport, null, 2))
       if (isLocalMode) {
@@ -581,33 +715,41 @@ function printLocalSummary(parsed, reportPath, report = null) {
       process.exit(0)
     }
 
-    console.log('🤖 AI Model being used:', AI_MODEL);
-    console.log('🔄 Using responses API for plain text output...')
-    const ai = await openai.responses.create({
+    console.log('🤖 AI Model being used:', AI_MODEL)
+    if (reviewContext.reviewInstructions) {
+      console.log('📚 Loaded repository-specific review instructions')
+    }
+    console.log('🔄 Using responses API with structured review output...')
+    const ai = await createReviewResponse({
       model: AI_MODEL,
-      input: getReviewPrompt(reviewContext.title, reviewContext.body, diff),
+      input: getReviewPrompt(reviewContext.title, reviewContext.body, diff, reviewContext.reviewInstructions),
       temperature: 0,
-      // No response_format specified = plain text output
+      max_output_tokens: maxOutputTokens,
+      reasoning: { effort: reasoningEffort },
+      store: false,
+      text: {
+        format: {
+          type: 'json_schema',
+          name: 'ai_code_review',
+          strict: true,
+          schema: reviewResponseSchema,
+        },
+      },
     })
     console.log('✅ Responses API call succeeded')
-
-    // Debug: Log the full response structure
-    console.log('🔍 Full AI response structure:', JSON.stringify(ai, null, 2))
 
     // Extract content from responses API format
     const text = ai.output_text || ai.response?.content || ai.content
     
     if (!text || text.trim() === '') {
       console.error('❌ AI returned empty response')
-      console.error('❌ Response structure:', JSON.stringify(ai, null, 2))
       throw new Error('AI returned empty response')
     }
     
     console.log('📝 AI Response length:', text.length)
-    console.log('📝 AI Response preview:', text.substring(0, 500))
     
-    // Parse plain text response
-    const parsed = extractIssuesFromText(text)
+    // Parse structured response, with a text-parser fallback for older model/action behavior.
+    const parsed = parseReviewResponse(text)
     console.log('✅ Successfully parsed AI response')
     console.log(`📊 Found ${parsed.issues.length} issues with overall risk: ${parsed.overall_risk}`)
 
@@ -621,6 +763,7 @@ function printLocalSummary(parsed, reportPath, report = null) {
       timestamp: new Date().toISOString(),
       model: AI_MODEL,
       mode: isLocalMode ? 'local' : 'github-action',
+      diff_metadata: diffMetadata,
     }
     fs.writeFileSync(reportPath, JSON.stringify(fullReport, null, 2))
     console.log(`AI review report written to: ${reportPath}`)
@@ -633,7 +776,7 @@ function printLocalSummary(parsed, reportPath, report = null) {
     // 4) Post (or update) a single summary comment
     if (reviewContext.shouldPostComment) {
       const marker = '<!-- ai-code-review-bot -->'
-      const bodyMd = `${marker}\n${asMarkdown(parsed)}\n${marker}`
+      const bodyMd = `${marker}\n${asMarkdown(parsed, diffMetadata)}\n${marker}`
       const allComments = await octo.paginate(octo.issues.listComments, {
         owner,
         repo,


### PR DESCRIPTION
## Summary

- update the default AI review model to `gpt-5.5`
- add workflow-level `review_instructions` for repository context
- switch review parsing to structured JSON output
- tune review execution with bounded files, output tokens, medium reasoning, and no response storage
- surface coverage notes when large PRs are truncated or capped
- bump the action package to `v1.2.4` and rebuild `dist/index.js`

## Validation

- `npm run build`
- `node --check src/review.js`
- `node --check dist/index.js`
- action input/default validation via `js-yaml`
