### PR TITLE
Move action runtime to Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,12 +12,12 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "npm"
 
       - name: Install dependencies
@@ -32,7 +32,7 @@ jobs:
           tar -czf ai-code-review-github-action.tar.gz -C . --exclude=.git --exclude=node_modules --exclude=.github *
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: ./ai-code-review-github-action.tar.gz
           generate_release_notes: true

--- a/action.yml
+++ b/action.yml
@@ -56,5 +56,5 @@ inputs:
     default: 12000
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "main": "src/review.js",
     "scripts": {
         "review:local": "node src/review.js --local",
-        "build": "esbuild src/review.js --bundle --platform=node --target=node20 --format=cjs --outfile=dist/index.js --banner:js=\"#!/usr/bin/env node\" --external:node:fs --external:node:path --external:node:stream --external:node:util --external:node:crypto --external:node:http --external:node:https --external:node:url --external:node:os --external:node:child_process",
+        "build": "esbuild src/review.js --bundle --platform=node --target=node24 --format=cjs --outfile=dist/index.js --banner:js=\"#!/usr/bin/env node\" --external:node:fs --external:node:path --external:node:stream --external:node:util --external:node:crypto --external:node:http --external:node:https --external:node:url --external:node:os --external:node:child_process",
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "dependencies": {


### PR DESCRIPTION
## Summary

- move the action runtime from Node 20 to Node 24
- build the bundled action for Node 24
- update CI and release workflows to use Node 24
- update workflow actions to current Node 24-compatible majors

## Validation

- `npm run build`
- `node --check src/review.js`
- `node --check dist/index.js`
- YAML parse for `action.yml`, CI, and release workflows
